### PR TITLE
Remove Electron artifact files from template ZIP file

### DIFF
--- a/build-template.js
+++ b/build-template.js
@@ -136,32 +136,9 @@ Promise.resolve()
         path.join(TEMPLATE_PATH, 'node_modules', 'electron', 'index.js'),
       ),
       fs.copy(
-        path.join(__dirname, 'node_modules', 'electron', 'path.txt'),
-        path.join(TEMPLATE_PATH, 'node_modules', 'electron', 'path.txt'),
-      ),
-      fs.copy(
         path.join(__dirname, 'node_modules', 'electron', 'LICENSE'),
         path.join(TEMPLATE_PATH, 'node_modules', 'electron', 'LICENSE'),
       ),
-      // based on electron/install.js
-      Promise.resolve()
-        .then(() => {
-          console.log(`Preparing electron for ${platform} ${arch}...`);
-          return downloadArtifact({
-            version: electronVersion,
-            artifactName: 'electron',
-            force: process.env.force_no_cache === 'true',
-            cacheRoot: process.env.electron_config_cache,
-            platform,
-            arch,
-          });
-        })
-        .then((zipPath) => {
-          console.log('Downloaded to', zipPath);
-          const distPath = path.join(TEMPLATE_PATH, 'node_modules', 'electron', 'dist');
-          console.log('Extracting to', distPath);
-          return extract(zipPath, { dir: distPath });
-        }),
     ];
 
     return Promise.all(tasks);

--- a/build-template.js
+++ b/build-template.js
@@ -6,8 +6,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const tmp = require('tmp');
 const builder = require('electron-builder');
-const { downloadArtifact } = require('@electron/get');
-const extract = require('extract-zip');
 
 const platform = process.env.TEMPLATE_PLATFORM || process.platform;
 const arch = process.env.TEMPLATE_ARCH || 'x64';
@@ -111,8 +109,6 @@ Promise.resolve()
     const resourcesPath = targetName === 'mac'
       ? path.join(dotAppPath, 'Contents', 'Resources')
       : path.join(dotAppPath, 'resources');
-
-    const electronVersion = fs.readJSONSync(path.join(__dirname, 'package.json')).devDependencies.electron;
 
     const tasks = [
       fs.copy(


### PR DESCRIPTION
`electron-packager` won't use it but instead re-download the zip file so basically the large artificate files are useless.