### PR TITLE
Revert "Fix top area of browser view is not clickable on Windows & Linux (#251)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "concurrently": "5.3.0",
     "cross-env": "7.0.3",
     "date-fns": "2.16.1",
-    "electron": "11.0.3",
+    "electron": "11.1.1",
     "electron-builder": "22.10.3",
     "eslint": "6.8.0",
     "eslint-config-airbnb": "18.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5868,10 +5868,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.3.tgz#c29eaacda38ce561890e59906ca5f507c72b3ec4"
-  integrity sha512-nNfbLi7Q1xfJXOEO2adck5TS6asY4Jxc332E4Te8XfQ9hcaC3GiCdeEqk9FndNCwxhJA5Lr9jfSGRTwWebFa/w==
+electron@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.1.tgz#188f036f8282798398dca9513e9bb3b10213e3aa"
+  integrity sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
This reverts commit c6e3b16cefaaf3c45b97f4e779ed7c19b50ec343.

Fix https://github.com/webcatalog/webcatalog-app/issues/1255

See:
- https://github.com/electron/electron/issues/26819
- https://github.com/electron/electron/pull/26749