### PR TITLE
Use system title bar and borders by default on Windows & Linux

### DIFF
--- a/public/libs/preferences.js
+++ b/public/libs/preferences.js
@@ -90,7 +90,8 @@ const defaultPreferences = {
   trayIcon: false,
   unreadCountBadge: true,
   useHardwareAcceleration: true,
-  useSystemTitleBar: false,
+  // revert useSystemTitleBar to false when https://github.com/electron/electron/issues/27131 is resolved
+  useSystemTitleBar: true,
   warnBeforeQuitting: false,
 };
 


### PR DESCRIPTION
See:
- https://github.com/electron/electron/issues/27131
- https://github.com/webcatalog/webcatalog-app/issues/1254
- https://github.com/webcatalog/webcatalog-app/issues/1237