### PR TITLE
Revert "Use system title bar and borders by default on Windows & Linux (#253)"

### DIFF
--- a/public/libs/preferences.js
+++ b/public/libs/preferences.js
@@ -92,8 +92,7 @@ const defaultPreferences = {
   trayIcon: false,
   unreadCountBadge: true,
   useHardwareAcceleration: true,
-  // revert useSystemTitleBar to false when https://github.com/electron/electron/issues/27131 is resolved
-  useSystemTitleBar: true,
+  useSystemTitleBar: false,
   warnBeforeQuitting: false,
 };
 


### PR DESCRIPTION
This reverts commit b205c78d8137a27e5dddb5058c0cf3f1b4c5ad6e.